### PR TITLE
Fix global progress total for JSON updates

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -947,7 +947,7 @@ namespace DepotDownloader
             GlobalDownloadCounter downloadCounter, DepotFilesData depotFilesData, HashSet<string> allFileNamesAllDepots)
         {
             var depot = depotFilesData.depotDownloadInfo;
-            var depotCounter = depotFilesData.depotCounter;
+            var depotDownloadCounter = depotFilesData.depotCounter;
 
             Console.WriteLine("Downloading depot {0}", depot.DepotId);
 
@@ -1020,7 +1020,7 @@ namespace DepotDownloader
             DepotConfigStore.Instance.InstalledManifestIDs[depot.DepotId] = depot.ManifestId;
             DepotConfigStore.Save();
 
-            Console.WriteLine("Depot {0} - Downloaded {1} bytes ({2} bytes uncompressed)", depot.DepotId, depotCounter.depotBytesCompressed, depotCounter.depotBytesUncompressed);
+            Console.WriteLine("Depot {0} - Downloaded {1} bytes ({2} bytes uncompressed)", depot.DepotId, depotDownloadCounter.depotBytesCompressed, depotDownloadCounter.depotBytesUncompressed);
             depotDownloadCounter.sizeDownloaded = depotDownloadCounter.completeDownloadSize;
             EmitProgressThrottled(depotDownloadCounter);
         }
@@ -1187,7 +1187,6 @@ namespace DepotDownloader
 
                         var percent = (depotDownloadCounter.sizeDownloaded / (float)depotDownloadCounter.completeDownloadSize) * 100.0f;
                         Console.WriteLine("{0,6:#00.00}% {1}", percent, fileFinalPath);
-                        depotDownloadCounter.sizeDownloaded += (ulong)chunkBytesWritten;  // e.g. (ulong)chunk.CompressedLength
                         EmitProgressThrottled(depotDownloadCounter);
 
                         try
@@ -1397,9 +1396,11 @@ namespace DepotDownloader
                 downloadCounter.totalBytesCompressed += chunk.CompressedLength;
                 downloadCounter.totalBytesUncompressed += chunk.UncompressedLength;
 
-                // You already had this — keep it:
-                Ansi.Progress(downloadCounter.totalBytesUncompressed,
-                              downloadCounter.completeDownloadSize);
+                // use the original total size: downloaded + remaining
+                Ansi.Progress(
+                    downloadCounter.totalBytesUncompressed,
+                    downloadCounter.totalBytesUncompressed + downloadCounter.completeDownloadSize
+                );
             }
 
             if (remainingChunks == 0)

--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using SteamKit2;
@@ -61,7 +62,7 @@ namespace DepotDownloader
                 ulong total = c.completeDownloadSize;
 
                 byte pct = total == 0
-                    ? (byte)0
+                    ? (byte)100
                     : (byte)Math.Clamp((int)Math.Round(downloaded * 100.0 / total), 0, 100);
 
                 var now = DateTime.UtcNow;


### PR DESCRIPTION
## Summary
- compute overall progress total using downloaded + remaining bytes to keep JSON progress file accurate

## Testing
- `dotnet publish -c Release -r linux-arm64 --self-contained true -p:PublishSingleFile=true -o ./publish/linux-arm64`


------
https://chatgpt.com/codex/tasks/task_e_6897df79dd208324abe0b50b5de48055